### PR TITLE
fix(telegram): graceful "two pollers" conflict + deploy troubleshooting

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -202,6 +202,11 @@ services:
 
 ---
 
+## Troubleshooting
+
+- **Deployed app shows no tickers / history.** Data lives in the database, and the watchlist is **shared (not per-user)** — logging in with the same email doesn't carry data over. The backend's `DATABASE_URL` must point at your Supabase; if it's unset the app silently falls back to an **ephemeral SQLite file inside the container** (empty, and wiped on every redeploy). Set `DATABASE_URL` on the backend to the **same** Supabase URL you use locally, then redeploy.
+- **Telegram `Conflict: terminated by other getUpdates request`.** The bot token is being polled in **two places at once** (Telegram allows only one poller per token). Keep `ENABLE_BACKGROUND_JOBS=true` on exactly **one** instance — your deploy — and set it to **false** everywhere else (e.g. your local `.env`), or stop the other instance.
+
 ## Notes
 - **DB schema auto-creates** on first backend boot (`init_db` + pgvector `ensure_schema`); if the pooler role can't `CREATE EXTENSION vector`, enable it once in Supabase → Database → Extensions.
 - **Free Render web services sleep** after ~15 min idle (slow cold start). Use Starter for always-on, or — if you run the bot/scheduler in-process (`ENABLE_BACKGROUND_JOBS`) — keep the free service awake with an uptime pinger (see the Telegram section).

--- a/stockstalker/integrations/telegram.py
+++ b/stockstalker/integrations/telegram.py
@@ -34,6 +34,7 @@ class StockStalkerBot:
     def __init__(self, runner: PipelineRunner) -> None:
         self.runner = runner
         self.app = Application.builder().token(settings.telegram_bot_token).build()
+        self._conflict_warned = False
         self._register_handlers()
         logger.info("StockStalkerBot initialized")
 
@@ -301,8 +302,28 @@ class StockStalkerBot:
         await self.app.initialize()
         await self._setup_profile()
         await self.app.start()
-        await self.app.updater.start_polling(drop_pending_updates=True)
+        await self.app.updater.start_polling(
+            drop_pending_updates=True, error_callback=self._on_poll_error
+        )
         logger.info("Bot polling started")
+
+    def _on_poll_error(self, exc: Exception) -> None:
+        """Keep polling errors quiet + actionable — notably the 'two instances'
+        Conflict you get when this bot token is polled in more than one place
+        (e.g. running locally while the deployed app is also polling). Telegram
+        allows only ONE getUpdates poller per token."""
+        from telegram.error import Conflict
+
+        if isinstance(exc, Conflict):
+            if not self._conflict_warned:
+                self._conflict_warned = True
+                logger.warning(
+                    "Telegram polling conflict: this bot token is already being polled "
+                    "elsewhere (likely your deployed app). Run the bot in ONE place — "
+                    "set ENABLE_BACKGROUND_JOBS=false here, or stop the other instance."
+                )
+        else:
+            logger.warning("Telegram polling error: {}", exc)
 
     async def _setup_profile(self) -> None:
         """Register the slash-command menu + bot description shown in Telegram's UI.


### PR DESCRIPTION
When the bot token is polled in two places (e.g. local + the deployed app), Telegram returns Conflict and PTB spammed a full traceback every few seconds. Add a polling error_callback that logs ONE actionable warning instead. The real fix is config (run the bot in one place: ENABLE_BACKGROUND_JOBS=true on the deploy, false locally) — now documented in DEPLOYMENT.md, alongside the "deployed app shows no data -> set DATABASE_URL to your Supabase" gotcha.